### PR TITLE
Returning a list of Match instead of a list of K for recognito.recognize

### DIFF
--- a/recognito/src/main/java/com/bitsinharmony/recognito/Match.java
+++ b/recognito/src/main/java/com/bitsinharmony/recognito/Match.java
@@ -1,0 +1,23 @@
+package com.bitsinharmony.recognito;
+
+/**
+ *
+ * @author skarack
+ */
+public class Match<K> {
+    private final Double distance;
+    private final K userKey;
+    
+    public Match(Double distance, K userKey) {
+        this.distance = distance;
+        this.userKey = userKey;
+    }
+    
+    public Double getDistance() {
+        return distance;
+    }
+    
+    public K getUserKey() {
+        return userKey;
+    }
+}

--- a/recognito/src/main/java/com/bitsinharmony/recognito/Recognito.java
+++ b/recognito/src/main/java/com/bitsinharmony/recognito/Recognito.java
@@ -204,7 +204,7 @@ public class Recognito<K> {
      * @param sampleRate the sample rate
      * @return a list of user keys that might match this vocal sample
      */
-    public List<K> recognize(double[] vocalSample, float sampleRate) {
+    public List<Match<K>> recognize(double[] vocalSample, float sampleRate) {
 
         VocalPrint vocalPrint = new VocalPrint(extractFeatures(vocalSample, sampleRate));
         
@@ -216,10 +216,10 @@ public class Recognito<K> {
             results.put(distance, entry.getKey());
         }
         
-        List<K> returnValue = new ArrayList<K>();
+        List<Match<K>> returnValue = new ArrayList<Match<K>>();
         int i = 0;
         for(Entry<Double, K> entry : results.entrySet()) {
-            returnValue.add(entry.getValue());
+            returnValue.add(new Match<K>(entry.getKey(), entry.getValue()));
             if(++i == 3) {
                 break;
             }
@@ -238,7 +238,7 @@ public class Recognito<K> {
      * @throws IOException when an I/O exception occurs
      * @see Recognito#recognize(double[], float)
      */
-    public  List<K> recognize(File vocalSampleFile) 
+    public  List<Match<K>> recognize(File vocalSampleFile) 
             throws UnsupportedAudioFileException, IOException {
         
         AudioInputStream sample = AudioSystem.getAudioInputStream(vocalSampleFile);

--- a/recognito/src/test/java/com/bitsinharmony/recognito/RecognitoTest.java
+++ b/recognito/src/test/java/com/bitsinharmony/recognito/RecognitoTest.java
@@ -91,11 +91,11 @@ public class RecognitoTest {
             vp5.getDistance((DistanceCalculator) any, (VocalPrint) any); result = 1.0D;
         }};
         
-        List<String> keys = recognito.recognize(vocalSample, DEFAULT_SAMPLE_RATE);
+        List<Match<String>> keys = recognito.recognize(vocalSample, DEFAULT_SAMPLE_RATE);
 
-        assertThat(keys.get(0), is(equalTo("5")));
-        assertThat(keys.get(1), is(equalTo("4"))); 
-        assertThat(keys.get(2), is(equalTo("3")));
+        assertThat(keys.get(0).getUserKey(), is(equalTo("5")));
+        assertThat(keys.get(1).getUserKey(), is(equalTo("4"))); 
+        assertThat(keys.get(2).getUserKey(), is(equalTo("3")));
         assertThat(keys.size(), is(equalTo(3)));
     }
     
@@ -110,10 +110,10 @@ public class RecognitoTest {
             vp2.getDistance((DistanceCalculator) any, (VocalPrint) any); result = 4.0D;
         }};
         
-        List<String> keys = recognito.recognize(vocalSample, DEFAULT_SAMPLE_RATE);
+        List<Match<String>> keys = recognito.recognize(vocalSample, DEFAULT_SAMPLE_RATE);
 
-        assertThat(keys.get(0), is(equalTo("2")));
-        assertThat(keys.get(1), is(equalTo("1"))); 
+        assertThat(keys.get(0).getUserKey(), is(equalTo("2")));
+        assertThat(keys.get(1).getUserKey(), is(equalTo("1"))); 
         assertThat(keys.size(), is(equalTo(2)));
     }
 


### PR DESCRIPTION
recognize now returns a list of Matches.
A match contains the UserKey and the distance. Since, right now, recognito always returns a match
a user can use the distance to decide if the match is usable.
