### PR TITLE
Specify javac source/target to fix override annotation problem

### DIFF
--- a/recognito/pom.xml
+++ b/recognito/pom.xml
@@ -40,4 +40,19 @@
 			</exclusions>
 		</dependency>
 	</dependencies>
+	
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.1</version>
+                <configuration>
+                	<source>1.6</source>
+                	<target>1.6</target>
+                </configuration>
+			</plugin>
+		</plugins>
+	</build>
+	
 </project>


### PR DESCRIPTION
Project failed to build for me due to the @Override annotations on methods from Runnable and Callable in VoicePrintConcurrencyTest.java. This is because that annotation is only allowed on interface methods from Java 1.6 onwards. By specifying the source and target versions in the POM (instead of accepting whatever defaults may be in effect from IDE, etc.), the error is fixed.
