### PR TITLE
add addVoicePrint methods

### DIFF
--- a/recognito/src/main/java/com/bitsinharmony/recognito/Recognito.java
+++ b/recognito/src/main/java/com/bitsinharmony/recognito/Recognito.java
@@ -212,6 +212,55 @@ public class Recognito<K> {
 
         return createVoicePrint(userKey, audioSample);
     }
+	
+		/**
+     * Add a voiceprint object. 
+     * <p>
+     * Threading : this method is synchronized to prevent inadvertently erasing an existing user key
+     * </p>
+     * @param userKey the user key associated with this voice print
+     * @param voiceSample the voice print object
+     * @return the voice print itself
+     */
+	
+	public synchronized VoicePrint addVoicePrint(K userKey, VoicePrint voicePrint) {
+		synchronized (this) {
+            if (!universalModelWasSetByUser.get()) {
+                if (universalModel == null) {
+                    universalModel = new VoicePrint(voicePrint);
+                } else {
+                    universalModel.merge(voicePrint.getFeatures());
+                }
+            }
+        }
+		store.put(userKey, voicePrint);
+        return voicePrint;
+	}
+
+    /**
+     * Add a voiceprint based on a current feature vector. 
+     * <p>
+     * Threading : this method is synchronized to prevent inadvertently erasing an existing user key
+     * </p>
+     * @param userKey the user key associated with this voice print
+     * @param features the feature array
+     * @return the voice print extracted from the given features
+     */
+	
+	public synchronized VoicePrint addVoicePrint(K userKey, double[] features) {
+		VoicePrint voicePrint = new VoicePrint(features);
+		synchronized (this) {
+            if (!universalModelWasSetByUser.get()) {
+                if (universalModel == null) {
+                    universalModel = new VoicePrint(voicePrint);
+                } else {
+                    universalModel.merge(features);
+                }
+            }
+        }
+		addVoicePrint(userKey, voicePrint);
+		return voicePrint;
+	}
 
     /**
      * Converts the given audio file to an array of doubles with values between -1.0 and 1.0

--- a/recognito/src/main/java/com/bitsinharmony/recognito/VoicePrint.java
+++ b/recognito/src/main/java/com/bitsinharmony/recognito/VoicePrint.java
@@ -128,4 +128,12 @@ public final class VoicePrint
         return Arrays.toString(features);
     }
     
+	/**
+     * Returns the features.
+     * @return the feature array
+     */
+	
+	public double[] getFeatures() {
+		return features;
+	}
 }


### PR DESCRIPTION
The class VoicePrint implements the interface Serializable. After persisting these files, as far as i can see, there is no method to "load" exactly these voiceprint again into the recognito-object without having the wavfiles. The advantage of these implemented method is, that there is no need to have the wav-files anymore for comparing against voiceprints. Especially the size of wav-files could be a problem for a situation with a lot of wav-files. This implementation could be a solution for this problem.