### PR TITLE
Work with Java 9

### DIFF
--- a/recognito/pom.xml
+++ b/recognito/pom.xml
@@ -22,9 +22,9 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>com.googlecode.jmockit</groupId>
+			<groupId>org.jmockit</groupId>
 			<artifactId>jmockit</artifactId>
-			<version>1.5</version>
+			<version>1.24</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/recognito/pom.xml
+++ b/recognito/pom.xml
@@ -52,6 +52,13 @@
                 	<target>1.6</target>
                 </configuration>
 			</plugin>
+			<plugin>
+			<artifactId>maven-surefire-plugin</artifactId>
+				<version>2.20.1</version>
+				<configuration>
+					<argLine>-Djdk.attach.allowAttachSelf</argLine>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 	

--- a/recognito/pom.xml
+++ b/recognito/pom.xml
@@ -24,7 +24,7 @@
 		<dependency>
 			<groupId>org.jmockit</groupId>
 			<artifactId>jmockit</artifactId>
-			<version>1.25</version>
+			<version>1.38</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/recognito/pom.xml
+++ b/recognito/pom.xml
@@ -24,7 +24,7 @@
 		<dependency>
 			<groupId>org.jmockit</groupId>
 			<artifactId>jmockit</artifactId>
-			<version>1.24</version>
+			<version>1.25</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/recognito/src/test/java/com/bitsinharmony/recognito/RecognitoTest.java
+++ b/recognito/src/test/java/com/bitsinharmony/recognito/RecognitoTest.java
@@ -87,7 +87,7 @@ public class RecognitoTest {
         recognito.mergeVoiceSample("test", voiceSample);
         
         new Verifications() {{
-            onInstance(initial).merge((double[]) any);
+            initial.merge((double[]) any);
         }};
     }
     

--- a/recognito/src/test/java/com/bitsinharmony/recognito/RecognitoTest.java
+++ b/recognito/src/test/java/com/bitsinharmony/recognito/RecognitoTest.java
@@ -24,8 +24,8 @@ import static org.junit.Assert.assertThat;
 import java.util.List;
 import java.util.Random;
 
+import mockit.Expectations;
 import mockit.Mocked;
-import mockit.NonStrictExpectations;
 import mockit.Verifications;
 
 import org.junit.Before;
@@ -104,7 +104,7 @@ public class RecognitoTest {
         final VoicePrint vp4 = recognito.createVoicePrint("4", voiceSample);
         final VoicePrint vp5 = recognito.createVoicePrint("5", voiceSample);
 
-        new NonStrictExpectations(vp1, vp2, vp3, vp4, vp5) {{
+        new Expectations(vp1, vp2, vp3, vp4, vp5) {{
             vp1.getDistance((DistanceCalculator) any, (VoicePrint) any); result = 5.0D;
             vp2.getDistance((DistanceCalculator) any, (VoicePrint) any); result = 4.0D;
             vp3.getDistance((DistanceCalculator) any, (VoicePrint) any); result = 3.0D;

--- a/recognito/src/test/java/com/bitsinharmony/recognito/algorithms/windowing/HammingWindowFunctionTest.java
+++ b/recognito/src/test/java/com/bitsinharmony/recognito/algorithms/windowing/HammingWindowFunctionTest.java
@@ -20,6 +20,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertArrayEquals;
 
 import java.util.Arrays;
 
@@ -49,7 +50,7 @@ public class HammingWindowFunctionTest {
     @Test 
     public void avoidUnwantedRegressionDueToAlgorithmRefactoring() {
         
-        assertThat(f1, is(equalTo(sample)));
+        assertArrayEquals(sample, f1, 1E-15);
         
         // In case you need to reprint it after an improvement:
         /*

--- a/recognito/src/test/java/com/bitsinharmony/recognito/algorithms/windowing/HannWindowFunctionTest.java
+++ b/recognito/src/test/java/com/bitsinharmony/recognito/algorithms/windowing/HannWindowFunctionTest.java
@@ -20,6 +20,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertArrayEquals;
 
 import java.util.Arrays;
 
@@ -49,7 +50,7 @@ public class HannWindowFunctionTest {
     @Test 
     public void avoidUnwantedRegressionDueToAlgorithmRefactoring() {
         
-        assertThat(f1, is(equalTo(sample)));
+        assertArrayEquals(sample, f1, 1E-15);
         
         // In case you need to reprint it after an improvement:
         /*


### PR DESCRIPTION
* Upgrade to a JMockit that copes with JDK 9
* Remove use of now-removed JMockit API
* Pass necessary flags to run with JDK 9
* Tolerate slight differences in maths